### PR TITLE
Add speech recognition for dictation

### DIFF
--- a/frnt/src/components/ChatScreen.tsx
+++ b/frnt/src/components/ChatScreen.tsx
@@ -7,6 +7,8 @@ import CanvasPyInterpreter from './CanvasPyInterpreter';
 import StorageUtils from '../utils/storage';
 import { useVSCodeContext } from '../utils/llama-vscode';
 import { useChatTextarea, ChatTextareaApi } from './useChatTextarea.ts';
+import useSpeechToText from './useSpeechToText';
+import { MicrophoneIcon, StopIcon } from '@heroicons/react/24/outline';
 
 /**
  * A message display is a message node with additional information for rendering.
@@ -102,6 +104,9 @@ export default function ChatScreen() {
   } = useAppContext();
 
   const textarea: ChatTextareaApi = useChatTextarea(prefilledMsg.content());
+
+  const { start, stop, listening, supported } = useSpeechToText(textarea.setValue);
+  useEffect(() => stop, [stop]);
 
   const { extraContext, clearExtraContext } = useVSCodeContext(textarea);
   // TODO: improve this when we have "upload file" feature
@@ -284,6 +289,20 @@ export default function ChatScreen() {
               Send
             </button>
           )}
+          <button
+            className="btn btn-neutral ml-2"
+            onClick={listening ? stop : start}
+            disabled={!supported}
+            title={
+              supported ? undefined : 'Speech recognition not supported'
+            }
+          >
+            {listening ? (
+              <StopIcon className="h-6 w-6" />
+            ) : (
+              <MicrophoneIcon className="h-6 w-6" />
+            )}
+          </button>
         </div>
       </div>
       <div className="w-full sticky top-[7em] h-[calc(100vh-9em)]">

--- a/frnt/src/components/useSpeechToText.ts
+++ b/frnt/src/components/useSpeechToText.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface SpeechToTextApi {
+  start: () => void;
+  stop: () => void;
+  listening: boolean;
+  supported: boolean;
+}
+
+export default function useSpeechToText(
+  onResult: (text: string) => void
+): SpeechToTextApi {
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const [listening, setListening] = useState(false);
+  const supported =
+    typeof window !== 'undefined' &&
+    ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition);
+
+  const start = useCallback(() => {
+    if (!supported || listening) return;
+    const SpeechRecognitionCtor =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const recognition: SpeechRecognition = new SpeechRecognitionCtor();
+    recognitionRef.current = recognition;
+    recognition.interimResults = false;
+    recognition.onresult = (e: SpeechRecognitionEvent) => {
+      const transcript = Array.from(e.results)
+        .map((r) => r[0].transcript)
+        .join('');
+      onResult(transcript);
+    };
+    recognition.onend = () => {
+      setListening(false);
+    };
+    recognition.onerror = () => {
+      setListening(false);
+    };
+    recognition.start();
+    setListening(true);
+  }, [supported, listening, onResult]);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+    setListening(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+    };
+  }, []);
+
+  return { start, stop, listening, supported };
+}


### PR DESCRIPTION
## Summary
- introduce a `useSpeechToText` hook using the Web Speech API
- add microphone button in `ChatScreen` to start/stop dictation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*