### PR TITLE
Add MCP config canvas

### DIFF
--- a/frnt/src/components/CanvasMcpConfig.tsx
+++ b/frnt/src/components/CanvasMcpConfig.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { useAppContext } from '../utils/app.context';
+import { CanvasType } from '../utils/types';
+import { XCloseButton } from '../utils/common';
+
+interface PingResult {
+  [url: string]: string;
+}
+
+export default function CanvasMcpConfig() {
+  const { setCanvasData } = useAppContext();
+  const [tab, setTab] = useState(0);
+  const [config, setConfig] = useState<string>('Loading...');
+  const [resources, setResources] = useState<string[]>([]);
+  const [newRes, setNewRes] = useState('');
+  const [ping, setPing] = useState<PingResult>({});
+  const [prompts, setPrompts] = useState<unknown>(null);
+  const [tools, setTools] = useState<unknown>(null);
+
+  useEffect(() => {
+    fetch('/mcp_config.json')
+      .then((res) => res.json())
+      .then((data) => setConfig(JSON.stringify(data, null, 2)))
+      .catch(() => setConfig('Failed to load configuration'));
+  }, []);
+
+  const addResource = () => {
+    if (!newRes) return;
+    setResources([...resources, newRes]);
+    setNewRes('');
+  };
+
+  const pingResource = async (url: string) => {
+    const start = Date.now();
+    try {
+      await fetch(url, { method: 'HEAD' });
+      const ms = Date.now() - start;
+      setPing((p) => ({ ...p, [url]: `OK ${ms}ms` }));
+    } catch {
+      setPing((p) => ({ ...p, [url]: 'Error' }));
+    }
+  };
+
+  const loadPrompts = async () => {
+    try {
+      const data = await (await fetch('/prompts.json')).json();
+      setPrompts(data);
+    } catch {
+      setPrompts('Failed to load prompts');
+    }
+  };
+
+  const loadTools = async () => {
+    try {
+      const data = await (await fetch('/tools.json')).json();
+      setTools(data);
+    } catch {
+      setTools('Failed to load tools');
+    }
+  };
+
+  return (
+    <div className="card bg-base-200 w-full h-full shadow-xl">
+      <div className="card-body">
+        <div className="flex justify-between items-center mb-4">
+          <span className="text-lg font-bold">Model Context Protocol</span>
+          <XCloseButton className="bg-base-100" onClick={() => setCanvasData(null)} />
+        </div>
+        <div role="tablist" className="tabs tabs-boxed mb-2">
+          <a className={`tab ${tab === 0 ? 'tab-active' : ''}`} onClick={() => setTab(0)}>Config</a>
+          <a className={`tab ${tab === 1 ? 'tab-active' : ''}`} onClick={() => setTab(1)}>Resources</a>
+          <a className={`tab ${tab === 2 ? 'tab-active' : ''}`} onClick={() => setTab(2)}>Prompts</a>
+          <a className={`tab ${tab === 3 ? 'tab-active' : ''}`} onClick={() => setTab(3)}>Tools</a>
+        </div>
+        {tab === 0 && <pre className="overflow-auto text-sm h-full">{config}</pre>}
+        {tab === 1 && (
+          <div className="flex flex-col gap-2">
+            <div className="flex">
+              <input
+                className="input input-bordered grow mr-2"
+                value={newRes}
+                onChange={(e) => setNewRes(e.target.value)}
+                placeholder="Resource URL"
+              />
+              <button className="btn btn-sm" onClick={addResource}>
+                Add
+              </button>
+            </div>
+            <ul className="menu">
+              {resources.map((r) => (
+                <li key={r} className="flex flex-row items-center">
+                  <span className="grow truncate">{r}</span>
+                  <button className="btn btn-xs" onClick={() => pingResource(r)}>
+                    Ping
+                  </button>
+                  <span className="ml-2 text-xs">{ping[r]}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {tab === 2 && (
+          <div className="flex flex-col h-full overflow-auto">
+            <button className="btn btn-sm mb-2" onClick={loadPrompts}>
+              Load Prompts
+            </button>
+            <pre className="text-sm overflow-auto grow">
+              {prompts ? JSON.stringify(prompts, null, 2) : ''}
+            </pre>
+          </div>
+        )}
+        {tab === 3 && (
+          <div className="flex flex-col h-full overflow-auto">
+            <button className="btn btn-sm mb-2" onClick={loadTools}>
+              Load Tools
+            </button>
+            <pre className="text-sm overflow-auto grow">
+              {tools ? JSON.stringify(tools, null, 2) : ''}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frnt/src/components/ChatScreen.tsx
+++ b/frnt/src/components/ChatScreen.tsx
@@ -4,6 +4,7 @@ import ChatMessage from './ChatMessage';
 import { CanvasType, Message, PendingMessage } from '../utils/types';
 import { classNames, cleanCurrentUrl, throttle } from '../utils/misc';
 import CanvasPyInterpreter from './CanvasPyInterpreter';
+import CanvasMcpConfig from './CanvasMcpConfig';
 import StorageUtils from '../utils/storage';
 import { useVSCodeContext } from '../utils/llama-vscode';
 import { useChatTextarea, ChatTextareaApi } from './useChatTextarea.ts';
@@ -309,6 +310,7 @@ export default function ChatScreen() {
         {canvasData?.type === CanvasType.PY_INTERPRETER && (
           <CanvasPyInterpreter />
         )}
+        {canvasData?.type === CanvasType.MCP_CONFIG && <CanvasMcpConfig />}
       </div>
     </div>
   );

--- a/frnt/src/components/Header.tsx
+++ b/frnt/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import StorageUtils from '../utils/storage';
 import { useAppContext } from '../utils/app.context';
+import { CanvasType } from '../utils/types';
 import { classNames } from '../utils/misc';
 import daisyuiThemes from 'daisyui/theme/object';
 import { THEMES } from '../Config';
@@ -9,7 +10,8 @@ import { useNavigate } from 'react-router';
 export default function Header() {
   const navigate = useNavigate();
   const [selectedTheme, setSelectedTheme] = useState(StorageUtils.getTheme());
-  const { setShowSettings } = useAppContext();
+  const { setShowSettings, setCanvasData, isGenerating, viewingChat } =
+    useAppContext();
 
   const setTheme = (theme: string) => {
     StorageUtils.setTheme(theme);
@@ -24,7 +26,6 @@ export default function Header() {
     );
   }, [selectedTheme]);
 
-  const { isGenerating, viewingChat } = useAppContext();
   const isCurrConvGenerating = isGenerating(viewingChat?.conv.id ?? '');
 
   const removeConversation = () => {
@@ -123,6 +124,17 @@ export default function Header() {
               <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492M5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0" />
               <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115z" />
             </svg>
+          </button>
+        </div>
+
+        <div className="tooltip tooltip-bottom" data-tip="MCP Config">
+          <button
+            className="btn"
+            onClick={() =>
+              setCanvasData({ type: CanvasType.MCP_CONFIG })
+            }
+          >
+            MCP
           </button>
         </div>
 

--- a/frnt/src/utils/types.ts
+++ b/frnt/src/utils/types.ts
@@ -81,6 +81,7 @@ export type PendingMessage = Omit<Message, 'content'> & {
 
 export enum CanvasType {
   PY_INTERPRETER,
+  MCP_CONFIG,
 }
 
 export interface CanvasPyInterpreter {
@@ -88,4 +89,8 @@ export interface CanvasPyInterpreter {
   content: string;
 }
 
-export type CanvasData = CanvasPyInterpreter;
+export interface CanvasMcpConfig {
+  type: CanvasType.MCP_CONFIG;
+}
+
+export type CanvasData = CanvasPyInterpreter | CanvasMcpConfig;


### PR DESCRIPTION
## Summary
- allow switching to new canvas for MCP config
- implement `CanvasMcpConfig` tabs for mcp_config.json, resources, prompts, tools
- expose new canvas from header

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*