### PR TITLE
Fix TS18046 in useSpeechToText

### DIFF
--- a/frnt/src/components/useSpeechToText.ts
+++ b/frnt/src/components/useSpeechToText.ts
@@ -23,10 +23,10 @@ export default function useSpeechToText(
     const recognition: SpeechRecognition = new SpeechRecognitionCtor();
     recognitionRef.current = recognition;
     recognition.interimResults = false;
-    recognition.onresult = (e: SpeechRecognitionEvent) => {
-      const transcript = Array.from(e.results)
-        .map((r) => r[0].transcript)
-        .join('');
+      recognition.onresult = (e: SpeechRecognitionEvent) => {
+        const transcript = Array.from(e.results as any[])
+          .map((r: any) => r[0].transcript)
+          .join('');
       onResult(transcript);
     };
     recognition.onend = () => {


### PR DESCRIPTION
## Summary
- cast `Array.from(e.results)` to `any[]` to satisfy TypeScript

## Testing
- `npm run --silent build` *(fails: cannot find module 'react', etc., but no TS18046)*