### PR TITLE
Fix SpeechRecognition ctor typing

### DIFF
--- a/frnt/src/components/useSpeechToText.ts
+++ b/frnt/src/components/useSpeechToText.ts
@@ -14,7 +14,9 @@ export default function useSpeechToText(
   const [listening, setListening] = useState(false);
 
   // Resolve SpeechRecognition constructor across browsers
-  const speechRecognitionCtor: typeof SpeechRecognition | undefined =
+  const speechRecognitionCtor:
+    | (new () => SpeechRecognition)
+    | undefined =
     typeof window !== 'undefined'
       ? (window.SpeechRecognition || (window as any).webkitSpeechRecognition)
       : undefined;


### PR DESCRIPTION
## Summary
- fix typing for browser-provided SpeechRecognition constructor

## Testing
- `npm run build` *(fails: cannot find module '@eslint/js')*