### PR TITLE
Fix null check for serverId in executeTool

### DIFF
--- a/frnt/src/utils/mcp-client.ts
+++ b/frnt/src/utils/mcp-client.ts
@@ -464,7 +464,7 @@ export class MCPManager {
     toolNameOrArgs?: string | Record<string, any>,
     args?: Record<string, any>
   ): Promise<any> {
-    let serverId: string;
+    let serverId: string | undefined;
     let toolName: string;
     let arguments: Record<string, any>;
 
@@ -486,7 +486,7 @@ export class MCPManager {
         }
       }
       
-      if (!serverId!) {
+      if (!serverId) {
         throw new Error(`도구를 찾을 수 없습니다: ${toolName}`);
       }
     }


### PR DESCRIPTION
## Summary
- fix null check in `executeTool` so TypeScript can compile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*